### PR TITLE
Dynamic Block Ring Buffers

### DIFF
--- a/Intrinio.Collections.nuspec
+++ b/Intrinio.Collections.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>Intrinio.Collections</id>
-		<version>1.0.3</version>
+		<version>1.1.0</version>
 		<title>Intrinio.Collections</title>
 		<authors>Intrinio</authors>
 		<owners>Intrinio</owners>
@@ -10,7 +10,7 @@
 		<license type="file">LICENSE</license>
 		<projectUrl>https://github.com/intrinio/intrinio-collections</projectUrl>
 		<description>Intrinio library for high performance, special-use collections.</description>
-		<releaseNotes>Version 1.0.3 release.</releaseNotes>
+		<releaseNotes>Version 1.1.0 release.</releaseNotes>
 		<copyright>Copyright 2025 Intrinio</copyright>
 		<tags>collections high-performance real-time concurrency</tags>
 		<dependencies>

--- a/Intrinio.Collections/Intrinio.Collections.csproj
+++ b/Intrinio.Collections/Intrinio.Collections.csproj
@@ -12,7 +12,7 @@
         <PackageTags>collections high-performance real-time concurrency</PackageTags>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Version>1.0.3</Version>
+        <Version>1.1.0</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Intrinio.Collections/RingBuffers/DropOldestRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/DropOldestRingBuffer.cs
@@ -73,7 +73,7 @@ public class DropOldestRingBuffer : IRingBuffer
     /// </summary>
     /// <param name="blockToWrite">The byte block to copy from.</param>
     /// <returns>Whether the block was successfully enqueued or not.</returns>
-    public bool TryEnqueue(in ReadOnlySpan<byte> blockToWrite)
+    public bool TryEnqueue(ReadOnlySpan<byte> blockToWrite)
     {
         lock (_writeLock)
         {
@@ -104,7 +104,7 @@ public class DropOldestRingBuffer : IRingBuffer
     /// </summary>
     /// <param name="blockBuffer">The buffer to copy the byte block to.</param>
     /// <returns>Whether a block was successfully dequeued or not.</returns>
-    public bool TryDequeue(in Span<byte> blockBuffer)
+    public bool TryDequeue(Span<byte> blockBuffer)
     {
         lock (_readLock)
         {

--- a/Intrinio.Collections/RingBuffers/DropOldestRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/DropOldestRingBuffer.cs
@@ -1,11 +1,8 @@
 namespace Intrinio.Collections.RingBuffers;
 
 using System;
-using System.Linq;
 using System.Threading;
-using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
-using Intrinio.Collections.RingBuffers;
 
 /// <summary>
 /// A thread-safe implementation of the IRingBuffer (multiple producer and multiple consumer).  Full behavior: the oldest block in the ring buffer will be dropped. 

--- a/Intrinio.Collections/RingBuffers/DropOldestRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/DropOldestRingBuffer.cs
@@ -72,6 +72,7 @@ public class DropOldestRingBuffer : IRingBuffer
     /// Full behavior: the oldest block in the ring buffer will be dropped. 
     /// </summary>
     /// <param name="blockToWrite">The byte block to copy from.</param>
+    /// <returns>Whether the block was successfully enqueued or not.</returns>
     public bool TryEnqueue(in ReadOnlySpan<byte> blockToWrite)
     {
         lock (_writeLock)
@@ -102,6 +103,7 @@ public class DropOldestRingBuffer : IRingBuffer
     /// Thread-safe try dequeue.  Parameter "blockBuffer" MUST be of length BlockSize!
     /// </summary>
     /// <param name="blockBuffer">The buffer to copy the byte block to.</param>
+    /// <returns>Whether a block was successfully dequeued or not.</returns>
     public bool TryDequeue(in Span<byte> blockBuffer)
     {
         lock (_readLock)

--- a/Intrinio.Collections/RingBuffers/DynamicBlockSingleProducerRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/DynamicBlockSingleProducerRingBuffer.cs
@@ -1,17 +1,12 @@
-using System.Buffers.Binary;
-using System.Runtime.CompilerServices;
-
 namespace Intrinio.Collections.RingBuffers;
 
 using System;
-using System.Linq;
 using System.Threading;
-using System.Collections.Concurrent;
+using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
-using Intrinio.Collections.RingBuffers;
 
 /// <summary>
-/// 
+/// A read thread-safe, write not thread-safe implementation of the IDynamicBlockRingBuffer (single producer and multiple consumer), with support for tracking the used size of each byte-block.  Full behavior: the block trying to be enqueued will be dropped. 
 /// </summary>
 public class DynamicBlockSingleProducerRingBuffer: IDynamicBlockRingBuffer
 {

--- a/Intrinio.Collections/RingBuffers/DynamicBlockSingleProducerRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/DynamicBlockSingleProducerRingBuffer.cs
@@ -30,13 +30,13 @@ public class DynamicBlockSingleProducerRingBuffer: SingleProducerRingBuffer, IDy
     /// Not thread-safe try enqueue.  Parameter "blockToWrite" MUST be of length BlockSize! This is not safe for calling concurrently, and intended for use with a single producer.
     /// Full behavior: the block trying to be enqueued will be dropped. 
     /// </summary>
-    /// <param name="fullBlockToWrite">The byte block to copy from.</param>
-    /// <param name="usedBlock">Full block, windowed for the writable area and trimmed down to the used size.</param>
+    /// <param name="fullBlockToWrite">The byte block to copy from. MUST be of length BlockSize!</param>
+    /// <param name="usedLength">The length of used space in fullBlockToWrite, not including the section for used size tracking.  Use GetUsableArea to aid in this, and then use the length of that span after your further manipulation here.</param>
     /// <returns>Whether the block was successfully enqueued or not.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool TryEnqueue(Span<byte> fullBlockToWrite, ReadOnlySpan<byte> usedBlock)
+    public bool TryEnqueue(Span<byte> fullBlockToWrite, uint usedLength)
     {
-        BinaryPrimitives.WriteUInt32BigEndian(fullBlockToWrite, Convert.ToUInt32(usedBlock.Length));
+        BinaryPrimitives.WriteUInt32BigEndian(fullBlockToWrite, usedLength);
         return base.TryEnqueue(fullBlockToWrite);
     }
 
@@ -55,7 +55,7 @@ public class DynamicBlockSingleProducerRingBuffer: SingleProducerRingBuffer, IDy
     }
     
     /// <summary>
-    /// Slice the full block to the writable area (removing the internally tracked used size section).
+    /// Slice the full block to the usable area (removing the internally tracked used size section).
     /// </summary>
     /// <param name="fullBlockToTrim">The full sized block.</param>
     /// <returns>The fullBlockToTrim windowed without the internally tracked used size section.</returns>

--- a/Intrinio.Collections/RingBuffers/DynamicBlockSingleProducerRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/DynamicBlockSingleProducerRingBuffer.cs
@@ -4,27 +4,126 @@ using System.Runtime.CompilerServices;
 namespace Intrinio.Collections.RingBuffers;
 
 using System;
+using System.Linq;
+using System.Threading;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using Intrinio.Collections.RingBuffers;
 
 /// <summary>
 /// 
 /// </summary>
-public class DynamicBlockSingleProducerRingBuffer: SingleProducerRingBuffer, IDynamicBlockRingBuffer
+public class DynamicBlockSingleProducerRingBuffer: IDynamicBlockRingBuffer
 {
-    public uint UsableBlockSize { get { return base.BlockSize - sizeof(UInt32); } }
+    #region Data Members
+    private readonly byte[] _data;
+    private uint _blockNextReadIndex;
+    private uint _blockNextWriteIndex;
+    private readonly object _readLock;
+    private ulong _count;
+    private readonly uint _blockSize;
+    private readonly uint _blockCapacity;
+    private ulong _dropCount;
+    
+    public ulong Count { get { return Interlocked.Read(ref _count); } }
+    public uint BlockSize { get { return _blockSize; } }
+    public uint BlockCapacity { get { return _blockCapacity; } }
+    public ulong DropCount { get { return Interlocked.Read(ref _dropCount); } }
+
+    public bool IsEmpty
+    {
+        get
+        {
+            return IsEmptyNoLock();
+        }
+    }
+
+    public bool IsFull
+    {
+        get
+        {
+            return IsFullNoLock();
+        }
+    }
+
+    private readonly uint _usableBlockSize;
+
+    /// <summary>
+    /// The fixed usable size of each byte block.
+    /// </summary>
+    public uint UsableBlockSize
+    {
+        get
+        {
+            return _usableBlockSize;
+        }
+    }
+    #endregion //Data Members
     
     #region Constructors
 
     /// <summary>
-    /// A read thread-safe, write not thread-safe implementation of the IRingBuffer (single producer and multiple consumer).  Full behavior: the block trying to be enqueued will be dropped. Provides support for dealing with blocks of varying size less than or equal to block size minus sizeof(UInt32). The first sizeof(UInt32) bytes of each block are reserved for tracking the used size of that block. 
+    /// A read thread-safe, write not thread-safe implementation of the IDynamicBlockRingBuffer (single producer and multiple consumer).  Full behavior: the block trying to be enqueued will be dropped. Provides support for dealing with blocks of varying size less than or equal to block size minus sizeof(UInt32). The first sizeof(UInt32) bytes of each block are reserved for tracking the used size of that block. 
     /// </summary>
     /// <param name="blockSize">The fixed size of each byte block. Internally, the first sizeof(UInt32) of each block is reserved for tracking the used size of each block. /></param>
     /// <param name="blockCapacity">The fixed capacity of block count.</param>
-    public DynamicBlockSingleProducerRingBuffer(uint blockSize, uint blockCapacity) : base(blockSize, blockCapacity)
+    public DynamicBlockSingleProducerRingBuffer(uint blockSize, uint blockCapacity)
     {
-        
+        _blockSize = blockSize;
+        _blockCapacity = blockCapacity;
+        _usableBlockSize = _blockSize - sizeof(UInt32);
+        _blockNextReadIndex = 0u;
+        _blockNextWriteIndex = 0u;
+        _count = 0u;
+        _dropCount = 0UL;
+        _readLock = new object();
+        _data = new byte[blockSize * blockCapacity];
     }
 
     #endregion //Constructors
+    
+    /// <summary>
+    /// Not thread-safe try enqueue.  Parameter "blockToWrite" MUST be of length BlockSize! This is not safe for calling concurrently, and intended for use with a single producer.
+    /// Full behavior: the block trying to be enqueued will be dropped. 
+    /// </summary>
+    /// <param name="blockToWrite">The byte block to copy from.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryEnqueue(Span<byte> blockToWrite)
+    {
+        return TryEnqueue(blockToWrite, _usableBlockSize);
+    }
+
+    /// <summary>
+    /// Thread-safe try dequeue.  Parameter "blockBuffer" MUST be of length BlockSize!
+    /// </summary>
+    /// <param name="blockBuffer">The buffer to copy the byte block to.</param>
+    public bool TryDequeue(Span<byte> blockBuffer)
+    {
+        lock (_readLock)
+        {
+            if (IsEmptyNoLock())
+                return false;
+            
+            Span<byte> target = new Span<byte>(_data, Convert.ToInt32(_blockNextReadIndex * BlockSize), Convert.ToInt32(BlockSize));
+            target.CopyTo(blockBuffer);
+            
+            _blockNextReadIndex = (++_blockNextReadIndex) % BlockCapacity;
+            Interlocked.Decrement(ref _count);
+            return true;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool IsFullNoLock()
+    {
+        return Interlocked.Read(ref _count) == _blockCapacity;
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool IsEmptyNoLock()
+    {
+        return Interlocked.Read(ref _count) == 0UL;
+    }
 
     /// <summary>
     /// Not thread-safe try enqueue.  Parameter "blockToWrite" MUST be of length BlockSize! This is not safe for calling concurrently, and intended for use with a single producer.
@@ -37,7 +136,20 @@ public class DynamicBlockSingleProducerRingBuffer: SingleProducerRingBuffer, IDy
     public bool TryEnqueue(Span<byte> fullBlockToWrite, uint usedLength)
     {
         BinaryPrimitives.WriteUInt32BigEndian(fullBlockToWrite, usedLength);
-        return base.TryEnqueue(fullBlockToWrite);
+        
+        if (IsFullNoLock())
+        {
+            Interlocked.Increment(ref _dropCount);
+            return false;
+        }
+            
+        Span<byte> target = new Span<byte>(_data, Convert.ToInt32(_blockNextWriteIndex * BlockSize), Convert.ToInt32(BlockSize));
+        fullBlockToWrite.CopyTo(target);
+            
+        _blockNextWriteIndex = (++_blockNextWriteIndex) % BlockCapacity;
+        Interlocked.Increment(ref _count);
+
+        return true;
     }
 
     /// <summary>
@@ -49,7 +161,7 @@ public class DynamicBlockSingleProducerRingBuffer: SingleProducerRingBuffer, IDy
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryDequeue(Span<byte> fullBlockBuffer, out uint usedSize)
     {
-        bool result = base.TryDequeue(fullBlockBuffer);
+        bool result = TryDequeue(fullBlockBuffer);
         usedSize = BinaryPrimitives.ReadUInt32BigEndian(fullBlockBuffer);
         return result;
     }

--- a/Intrinio.Collections/RingBuffers/DynamicBlockSingleProducerRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/DynamicBlockSingleProducerRingBuffer.cs
@@ -1,0 +1,68 @@
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+
+namespace Intrinio.Collections.RingBuffers;
+
+using System;
+
+/// <summary>
+/// 
+/// </summary>
+public class DynamicBlockSingleProducerRingBuffer: SingleProducerRingBuffer, IDynamicBlockRingBuffer
+{
+    public uint UsableBlockSize { get { return base.BlockSize - sizeof(UInt32); } }
+    
+    #region Constructors
+
+    /// <summary>
+    /// A read thread-safe, write not thread-safe implementation of the IRingBuffer (single producer and multiple consumer).  Full behavior: the block trying to be enqueued will be dropped. Provides support for dealing with blocks of varying size less than or equal to block size minus sizeof(UInt32). The first sizeof(UInt32) bytes of each block are reserved for tracking the used size of that block. 
+    /// </summary>
+    /// <param name="blockSize">The fixed size of each byte block. Internally, the first sizeof(UInt32) of each block is reserved for tracking the used size of each block. /></param>
+    /// <param name="blockCapacity">The fixed capacity of block count.</param>
+    public DynamicBlockSingleProducerRingBuffer(uint blockSize, uint blockCapacity) : base(blockSize, blockCapacity)
+    {
+        
+    }
+
+    #endregion //Constructors
+
+    /// <summary>
+    /// Not thread-safe try enqueue.  Parameter "blockToWrite" MUST be of length BlockSize! This is not safe for calling concurrently, and intended for use with a single producer.
+    /// Full behavior: the block trying to be enqueued will be dropped. 
+    /// </summary>
+    /// <param name="fullBlockToWrite">The byte block to copy from.</param>
+    /// <param name="usedBlock">Full block, windowed for the writable area and trimmed down to the used size.</param>
+    /// <returns>Whether the block was successfully enqueued or not.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryEnqueue(in Span<byte> fullBlockToWrite, in Span<byte> usedBlock)
+    {
+        BinaryPrimitives.WriteUInt32BigEndian(fullBlockToWrite, Convert.ToUInt32(usedBlock.Length));
+        return base.TryEnqueue(fullBlockToWrite);
+    }
+
+    /// <summary>
+    /// Try to dequeue a byte block via copy to the provided buffer.
+    /// </summary>
+    /// <param name="fullBlockBuffer">The full sized buffer to copy the byte block to. Must be of BlockSize.</param>
+    /// <param name="trimmedBlock">The buffer, trimmed down to the used size.</param>
+    /// <returns>Whether the dequeue successfully retrieved a block or not.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryDequeue(in Span<byte> fullBlockBuffer, out ReadOnlySpan<byte> trimmedBlock)
+    {
+        bool result = base.TryDequeue(fullBlockBuffer);
+        uint size = BinaryPrimitives.ReadUInt32BigEndian(fullBlockBuffer);
+        trimmedBlock = fullBlockBuffer.Slice(sizeof(UInt32), Convert.ToInt32(size));
+        return result;
+    }
+    
+    /// <summary>
+    /// Slice the full block to the writable area (removing the internally tracked used size section).
+    /// </summary>
+    /// <param name="fullBlockToTrim">The full sized block.</param>
+    /// <param name="trimmedBlock">The full sized block, trimmed down to the writable area (internally tracked used size section removed).</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void GetWritableArea(in ReadOnlySpan<byte> fullBlockToTrim, out ReadOnlySpan<byte> trimmedBlock)
+    {
+        trimmedBlock = fullBlockToTrim.Slice(sizeof(UInt32));
+    }
+}

--- a/Intrinio.Collections/RingBuffers/IDynamicBlockRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/IDynamicBlockRingBuffer.cs
@@ -3,7 +3,7 @@ namespace Intrinio.Collections.RingBuffers;
 using System;
 
 /// <summary>
-/// 
+/// A fixed-size byte-block circular queue with support for tracking the used size of each byte-block.
 /// </summary>
 public interface IDynamicBlockRingBuffer
 {

--- a/Intrinio.Collections/RingBuffers/IDynamicBlockRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/IDynamicBlockRingBuffer.cs
@@ -17,9 +17,9 @@ public interface IDynamicBlockRingBuffer : IRingBuffer
     /// Full behavior: the block trying to be enqueued will be dropped. 
     /// </summary>
     /// <param name="fullBlockToWrite">The byte block to copy from.</param>
-    /// <param name="usedBlock">Full block, windowed for the writable area and trimmed down to the used size.</param>
+    /// <param name="usedLength">The length of used space in fullBlockToWrite, not including the section for used size tracking.  Use GetUsableArea to aid in this, and then use the length of that span after your further manipulation here.</param>
     /// <returns>Whether the block was successfully enqueued or not.</returns>
-    bool TryEnqueue(Span<byte> fullBlockToWrite, ReadOnlySpan<byte> usedBlock);
+    bool TryEnqueue(Span<byte> fullBlockToWrite, uint usedLength);
 
     /// <summary>
     /// Try to dequeue a byte block via copy to the provided buffer.

--- a/Intrinio.Collections/RingBuffers/IDynamicBlockRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/IDynamicBlockRingBuffer.cs
@@ -5,12 +5,56 @@ using System;
 /// <summary>
 /// 
 /// </summary>
-public interface IDynamicBlockRingBuffer : IRingBuffer
+public interface IDynamicBlockRingBuffer
 {
+    /// <summary>
+    /// The count of blocks currently in the ring buffer.
+    /// </summary>
+    ulong Count { get; }
+    
+    /// <summary>
+    /// The fixed size of each byte block.
+    /// </summary>
+    uint BlockSize { get; }
+    
+    /// <summary>
+    /// The fixed capacity of blocks in the ring buffer.
+    /// </summary>
+    uint BlockCapacity { get; }
+    
+    /// <summary>
+    /// The quantity of dropped blocks due to being full.
+    /// </summary>
+    ulong DropCount { get; }
+    
+    /// <summary>
+    /// Whether the ring buffer is currently empty.
+    /// </summary>
+    bool IsEmpty { get; }
+    
+    /// <summary>
+    /// Whether the ring buffer is currently full.
+    /// </summary>
+    bool IsFull { get; }
+    
     /// <summary>
     /// The fixed usable size of each byte block.
     /// </summary>
     uint UsableBlockSize { get; }
+    
+    /// <summary>
+    /// Try to enqueue a byte block via copy from the provided buffer.
+    /// </summary>
+    /// <param name="blockToWrite">The byte block to copy from.</param>
+    /// <returns>Whether the block was successfully enqueued or not.</returns>
+    bool TryEnqueue(Span<byte> blockToWrite);
+    
+    /// <summary>
+    /// Try to dequeue a byte block via copy to the provided buffer.
+    /// </summary>
+    /// <param name="blockBuffer">The buffer to copy the byte block to.</param>
+    /// <returns>Whether a block was successfully dequeued or not.</returns>
+    bool TryDequeue(Span<byte> blockBuffer);
 
     /// <summary>
     /// Not thread-safe try enqueue.  Parameter "blockToWrite" MUST be of length BlockSize! This is not safe for calling concurrently, and intended for use with a single producer.

--- a/Intrinio.Collections/RingBuffers/IDynamicBlockRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/IDynamicBlockRingBuffer.cs
@@ -1,0 +1,41 @@
+namespace Intrinio.Collections.RingBuffers;
+
+using System;
+
+/// <summary>
+/// 
+/// </summary>
+public interface IDynamicBlockRingBuffer : IRingBuffer
+{
+    /// <summary>
+    /// The fixed usable size of each byte block.
+    /// </summary>
+    uint UsableBlockSize { get; }
+
+    /// <summary>
+    /// Not thread-safe try enqueue.  Parameter "blockToWrite" MUST be of length BlockSize! This is not safe for calling concurrently, and intended for use with a single producer.
+    /// Full behavior: the block trying to be enqueued will be dropped. 
+    /// </summary>
+    /// <param name="fullBlockToWrite">The byte block to copy from.</param>
+    /// <param name="usedBlock">Full block, windowed for the writable area and trimmed down to the used size.</param>
+    /// <returns>Whether the block was successfully enqueued or not.</returns>
+    public bool TryEnqueue(in Span<byte> fullBlockToWrite, in Span<byte> usedBlock);
+
+    /// <summary>
+    /// Try to dequeue a byte block via copy to the provided buffer.
+    /// </summary>
+    /// <param name="fullBlockBuffer">The full sized buffer to copy the byte block to.</param>
+    /// <param name="trimmedBlock">The buffer, trimmed down to the used size.</param>
+    /// <returns>Whether the dequeue successfully retrieved a block or not.</returns>
+    public bool TryDequeue(in Span<byte> fullBlockBuffer, out ReadOnlySpan<byte> trimmedBlock);
+
+    /// <summary>
+    /// Slice the full block to the writable area (removing the internally tracked used size section).
+    /// </summary>
+    /// <param name="fullBlockToTrim">The full sized block.</param>
+    /// <param name="trimmedBlock">The full sized block, trimmed down to the writable area (internally tracked used size section removed).</param>
+    static void GetWritableArea(in ReadOnlySpan<byte> fullBlockToTrim, out ReadOnlySpan<byte> trimmedBlock)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Intrinio.Collections/RingBuffers/IDynamicBlockRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/IDynamicBlockRingBuffer.cs
@@ -19,22 +19,22 @@ public interface IDynamicBlockRingBuffer : IRingBuffer
     /// <param name="fullBlockToWrite">The byte block to copy from.</param>
     /// <param name="usedBlock">Full block, windowed for the writable area and trimmed down to the used size.</param>
     /// <returns>Whether the block was successfully enqueued or not.</returns>
-    public bool TryEnqueue(in Span<byte> fullBlockToWrite, in Span<byte> usedBlock);
+    bool TryEnqueue(Span<byte> fullBlockToWrite, ReadOnlySpan<byte> usedBlock);
 
     /// <summary>
     /// Try to dequeue a byte block via copy to the provided buffer.
     /// </summary>
     /// <param name="fullBlockBuffer">The full sized buffer to copy the byte block to.</param>
-    /// <param name="trimmedBlock">The buffer, trimmed down to the used size.</param>
+    /// <param name="usedSize">The used size of the full block.</param>
     /// <returns>Whether the dequeue successfully retrieved a block or not.</returns>
-    public bool TryDequeue(in Span<byte> fullBlockBuffer, out ReadOnlySpan<byte> trimmedBlock);
+    bool TryDequeue(Span<byte> fullBlockBuffer, out uint usedSize);
 
     /// <summary>
     /// Slice the full block to the writable area (removing the internally tracked used size section).
     /// </summary>
     /// <param name="fullBlockToTrim">The full sized block.</param>
-    /// <param name="trimmedBlock">The full sized block, trimmed down to the writable area (internally tracked used size section removed).</param>
-    static void GetWritableArea(in ReadOnlySpan<byte> fullBlockToTrim, out ReadOnlySpan<byte> trimmedBlock)
+    /// <returns>The fullBlockToTrim windowed without the internally tracked used size section.</returns>
+    static Span<byte> GetUsableArea(Span<byte> fullBlockToTrim)
     {
         throw new NotImplementedException();
     }

--- a/Intrinio.Collections/RingBuffers/IPartitionedDynamicBlockRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/IPartitionedDynamicBlockRingBuffer.cs
@@ -14,10 +14,10 @@ public interface IPartitionedDynamicBlockRingBuffer : IPartitionedRingBuffer
     /// Full behavior: the block trying to be enqueued will be dropped. 
     /// </summary>
     /// <param name="threadIndex">The zero based index for the channel to try enqueuing to. Max value is concurrency - 1.</param>
-    /// <param name="fullBlockToWrite">The byte block to copy from.</param>
-    /// <param name="usedBlock">Full block, windowed for the writable area and trimmed down to the used size.</param>
+    /// <param name="fullBlockToWrite">The full length byte block to copy from.</param>
+    /// <param name="usedLength">The length of used space in fullBlockToWrite, not including the section for used size tracking.  Use GetUsableArea to aid in this, and then use the length of that span after your further manipulation here.</param>
     /// <returns>Whether the block was successfully enqueued or not.</returns>
-    bool TryEnqueue(uint threadIndex, Span<byte> fullBlockToWrite, ReadOnlySpan<byte> usedBlock);
+    bool TryEnqueue(uint threadIndex, Span<byte> fullBlockToWrite, uint usedLength);
 
     /// <summary>
     /// Try to dequeue a byte block via copy to the provided buffer.

--- a/Intrinio.Collections/RingBuffers/IPartitionedDynamicBlockRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/IPartitionedDynamicBlockRingBuffer.cs
@@ -2,15 +2,68 @@ namespace Intrinio.Collections.RingBuffers;
 
 using System;
 
-public interface IPartitionedDynamicBlockRingBuffer : IPartitionedRingBuffer
+/// <summary>
+/// A fixed size group of single producer <see cref="Intrinio.Collections.RingBuffers.IDynamicBlockRingBuffer"/> partitioned by an index, so that multiple writers may have their own write channel without being locked, while consumption is channel agnostic and thread-safe.
+/// </summary>
+public interface IPartitionedDynamicBlockRingBuffer
 {
     /// <summary>
     /// The fixed usable size of each byte block.
     /// </summary>
     uint UsableBlockSize { get; }
+    
+    /// <summary>
+    /// The count of blocks currently in the ring buffer.
+    /// </summary>
+    ulong Count { get; }
+    
+    /// <summary>
+    /// The fixed size of each byte block.
+    /// </summary>
+    uint BlockSize { get; }
+    
+    /// <summary>
+    /// The fixed capacity of blocks in each ring buffer.
+    /// </summary>
+    uint EachQueueBlockCapacity { get; }
+    
+    /// <summary>
+    /// The fixed total capacity of blocks across all ring buffers.
+    /// </summary>
+    ulong TotalBlockCapacity { get; }
+    
+    /// <summary>
+    /// The quantity of dropped blocks due to being full. 
+    /// </summary>
+    ulong DropCount { get; }
+    
+    /// <summary>
+    /// Whether the ring buffer is currently empty.
+    /// </summary>
+    bool IsEmpty { get; }
+    
+    /// <summary>
+    /// Whether the ring buffer is currently full.
+    /// </summary>
+    bool IsFull { get; }
+    
+    /// <summary>
+    /// A try enqueue where for each value of threadIndex, only one thread will be calling concurrently at a time.  Parameter "blockToWrite" MUST be of length BlockSize!
+    /// </summary>
+    /// <param name="threadIndex">The zero based index for the channel to try enqueuing to. Max value is concurrency - 1.</param>
+    /// <param name="blockToWrite">The byte block to copy from.</param>
+    /// <returns>Whether the block was successfully enqueued or not.</returns>
+    bool TryEnqueue(uint threadIndex, Span<byte> blockToWrite);
+    
+    /// <summary>
+    /// Thread-safe try dequeue.  Parameter "blockBuffer" MUST be of length BlockSize!
+    /// </summary>
+    /// <param name="blockBuffer">The buffer to copy the byte block to.</param>
+    /// <returns>Whether a block was successfully dequeued or not.</returns>
+    bool TryDequeue(Span<byte> blockBuffer);
 
     /// <summary>
-    /// Not thread-safe try enqueue.  Parameter "blockToWrite" MUST be of length BlockSize! This is not safe for calling concurrently, and intended for use with a single producer.
+    /// Not thread-safe (for a single threadIndex) try enqueue.  Parameter "blockToWrite" MUST be of length BlockSize! This is not safe for calling concurrently on the same threadIndex, and intended for use with a single producer per index.
     /// Full behavior: the block trying to be enqueued will be dropped. 
     /// </summary>
     /// <param name="threadIndex">The zero based index for the channel to try enqueuing to. Max value is concurrency - 1.</param>
@@ -36,4 +89,18 @@ public interface IPartitionedDynamicBlockRingBuffer : IPartitionedRingBuffer
     {
         throw new NotImplementedException();
     }
+    
+    /// <summary>
+    /// The count of blocks currently in the ring buffer at the specified index.
+    /// </summary>
+    /// <param name="threadIndex">The zero based index for the channel to try enqueuing to. Max value is concurrency - 1.</param>
+    /// <returns></returns>
+    public ulong GetCount(int threadIndex);
+
+    /// <summary>
+    /// The quantity of dropped blocks due to being full at the specified index.
+    /// </summary>
+    /// <param name="threadIndex">The zero based index for the channel to try enqueuing to. Max value is concurrency - 1.</param>
+    /// <returns></returns>
+    public ulong GetDropCount(int threadIndex);
 }

--- a/Intrinio.Collections/RingBuffers/IPartitionedDynamicBlockRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/IPartitionedDynamicBlockRingBuffer.cs
@@ -1,0 +1,39 @@
+namespace Intrinio.Collections.RingBuffers;
+
+using System;
+
+public interface IPartitionedDynamicBlockRingBuffer : IPartitionedRingBuffer
+{
+    /// <summary>
+    /// The fixed usable size of each byte block.
+    /// </summary>
+    uint UsableBlockSize { get; }
+
+    /// <summary>
+    /// Not thread-safe try enqueue.  Parameter "blockToWrite" MUST be of length BlockSize! This is not safe for calling concurrently, and intended for use with a single producer.
+    /// Full behavior: the block trying to be enqueued will be dropped. 
+    /// </summary>
+    /// <param name="threadIndex">The zero based index for the channel to try enqueuing to. Max value is concurrency - 1.</param>
+    /// <param name="fullBlockToWrite">The byte block to copy from.</param>
+    /// <param name="usedBlock">Full block, windowed for the writable area and trimmed down to the used size.</param>
+    /// <returns>Whether the block was successfully enqueued or not.</returns>
+    public bool TryEnqueue(uint threadIndex, in Span<byte> fullBlockToWrite, in Span<byte> usedBlock);
+
+    /// <summary>
+    /// Try to dequeue a byte block via copy to the provided buffer.
+    /// </summary>
+    /// <param name="fullBlockBuffer">The full sized buffer to copy the byte block to.</param>
+    /// <param name="trimmedBlock">The buffer, trimmed down to the used size.</param>
+    /// <returns>Whether the dequeue successfully retrieved a block or not.</returns>
+    public bool TryDequeue(in Span<byte> fullBlockBuffer, out ReadOnlySpan<byte> trimmedBlock);
+
+    /// <summary>
+    /// Slice the full block to the writable area (removing the internally tracked used size section).
+    /// </summary>
+    /// <param name="fullBlockToTrim">The full sized block.</param>
+    /// <param name="trimmedBlock">The full sized block, trimmed down to the writable area (internally tracked used size section removed).</param>
+    static void GetWritableArea(in ReadOnlySpan<byte> fullBlockToTrim, ReadOnlySpan<byte> trimmedBlock)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Intrinio.Collections/RingBuffers/IPartitionedDynamicBlockRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/IPartitionedDynamicBlockRingBuffer.cs
@@ -17,22 +17,22 @@ public interface IPartitionedDynamicBlockRingBuffer : IPartitionedRingBuffer
     /// <param name="fullBlockToWrite">The byte block to copy from.</param>
     /// <param name="usedBlock">Full block, windowed for the writable area and trimmed down to the used size.</param>
     /// <returns>Whether the block was successfully enqueued or not.</returns>
-    public bool TryEnqueue(uint threadIndex, in Span<byte> fullBlockToWrite, in Span<byte> usedBlock);
+    bool TryEnqueue(uint threadIndex, Span<byte> fullBlockToWrite, ReadOnlySpan<byte> usedBlock);
 
     /// <summary>
     /// Try to dequeue a byte block via copy to the provided buffer.
     /// </summary>
     /// <param name="fullBlockBuffer">The full sized buffer to copy the byte block to.</param>
-    /// <param name="trimmedBlock">The buffer, trimmed down to the used size.</param>
+    /// <param name="usedSize">The used size of the full block.</param>
     /// <returns>Whether the dequeue successfully retrieved a block or not.</returns>
-    public bool TryDequeue(in Span<byte> fullBlockBuffer, out ReadOnlySpan<byte> trimmedBlock);
+    bool TryDequeue(Span<byte> fullBlockBuffer, out uint usedSize);
 
     /// <summary>
     /// Slice the full block to the writable area (removing the internally tracked used size section).
     /// </summary>
     /// <param name="fullBlockToTrim">The full sized block.</param>
-    /// <param name="trimmedBlock">The full sized block, trimmed down to the writable area (internally tracked used size section removed).</param>
-    static void GetWritableArea(in ReadOnlySpan<byte> fullBlockToTrim, ReadOnlySpan<byte> trimmedBlock)
+    /// <returns>The fullBlockToTrim windowed without the internally tracked used size section.</returns>
+    static Span<byte> GetUsableArea(Span<byte> fullBlockToTrim)
     {
         throw new NotImplementedException();
     }

--- a/Intrinio.Collections/RingBuffers/IPartitionedRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/IPartitionedRingBuffer.cs
@@ -17,14 +17,14 @@ public interface IPartitionedRingBuffer
     /// </summary>
     /// <param name="threadIndex">The zero based index for the channel to try enqueuing to. Max value is concurrency - 1.</param>
     /// <param name="blockToWrite">The byte block to copy from.</param>
-    /// <returns></returns>
-    bool TryEnqueue(int threadIndex, in ReadOnlySpan<byte> blockToWrite);
+    /// <returns>Whether the block was successfully enqueued or not.</returns>
+    bool TryEnqueue(uint threadIndex, in ReadOnlySpan<byte> blockToWrite);
     
     /// <summary>
     /// Thread-safe try dequeue.  Parameter "blockBuffer" MUST be of length BlockSize!
     /// </summary>
     /// <param name="blockBuffer">The buffer to copy the byte block to.</param>
-    /// <returns></returns>
+    /// <returns>Whether a block was successfully dequeued or not.</returns>
     bool TryDequeue(in Span<byte> blockBuffer);
     
     /// <summary>

--- a/Intrinio.Collections/RingBuffers/IPartitionedRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/IPartitionedRingBuffer.cs
@@ -67,7 +67,6 @@ public interface IPartitionedRingBuffer
     /// </summary>
     /// <param name="threadIndex">The zero based index for the channel to try enqueuing to. Max value is concurrency - 1.</param>
     /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ulong GetCount(int threadIndex);
 
     /// <summary>
@@ -75,6 +74,5 @@ public interface IPartitionedRingBuffer
     /// </summary>
     /// <param name="threadIndex">The zero based index for the channel to try enqueuing to. Max value is concurrency - 1.</param>
     /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ulong GetDropCount(int threadIndex);
 }

--- a/Intrinio.Collections/RingBuffers/IPartitionedRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/IPartitionedRingBuffer.cs
@@ -1,11 +1,6 @@
 namespace Intrinio.Collections.RingBuffers;
 
 using System;
-using System.Linq;
-using System.Threading;
-using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
-using Intrinio.Collections.RingBuffers;
 
 /// <summary>
 /// A fixed size group of single producer <see cref="Intrinio.Collections.RingBuffers.IRingBuffer"/> partitioned by an index, so that multiple writers may have their own write channel without being locked, while consumption is channel agnostic and thread-safe.

--- a/Intrinio.Collections/RingBuffers/IPartitionedRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/IPartitionedRingBuffer.cs
@@ -18,14 +18,14 @@ public interface IPartitionedRingBuffer
     /// <param name="threadIndex">The zero based index for the channel to try enqueuing to. Max value is concurrency - 1.</param>
     /// <param name="blockToWrite">The byte block to copy from.</param>
     /// <returns>Whether the block was successfully enqueued or not.</returns>
-    bool TryEnqueue(uint threadIndex, in ReadOnlySpan<byte> blockToWrite);
+    bool TryEnqueue(uint threadIndex, ReadOnlySpan<byte> blockToWrite);
     
     /// <summary>
     /// Thread-safe try dequeue.  Parameter "blockBuffer" MUST be of length BlockSize!
     /// </summary>
     /// <param name="blockBuffer">The buffer to copy the byte block to.</param>
     /// <returns>Whether a block was successfully dequeued or not.</returns>
-    bool TryDequeue(in Span<byte> blockBuffer);
+    bool TryDequeue(Span<byte> blockBuffer);
     
     /// <summary>
     /// The count of blocks currently in the ring buffer.

--- a/Intrinio.Collections/RingBuffers/IPartitionedRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/IPartitionedRingBuffer.cs
@@ -61,4 +61,20 @@ public interface IPartitionedRingBuffer
     /// Whether the ring buffer is currently full.
     /// </summary>
     bool IsFull { get; }
+
+    /// <summary>
+    /// The count of blocks currently in the ring buffer at the specified index.
+    /// </summary>
+    /// <param name="threadIndex">The zero based index for the channel to try enqueuing to. Max value is concurrency - 1.</param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ulong GetCount(int threadIndex);
+
+    /// <summary>
+    /// The quantity of dropped blocks due to being full at the specified index.
+    /// </summary>
+    /// <param name="threadIndex">The zero based index for the channel to try enqueuing to. Max value is concurrency - 1.</param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ulong GetDropCount(int threadIndex);
 }

--- a/Intrinio.Collections/RingBuffers/IRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/IRingBuffer.cs
@@ -1,11 +1,6 @@
 namespace Intrinio.Collections.RingBuffers;
 
 using System;
-using System.Linq;
-using System.Threading;
-using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
-using Intrinio.Collections.RingBuffers;
 
 /// <summary>
 /// A fixed-size byte-block circular queue.

--- a/Intrinio.Collections/RingBuffers/IRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/IRingBuffer.cs
@@ -16,14 +16,14 @@ public interface IRingBuffer
     /// Try to enqueue a byte block via copy from the provided buffer.
     /// </summary>
     /// <param name="blockToWrite">The byte block to copy from.</param>
-    /// <returns></returns>
+    /// <returns>Whether the block was successfully enqueued or not.</returns>
     bool TryEnqueue(in ReadOnlySpan<byte> blockToWrite);
     
     /// <summary>
     /// Try to dequeue a byte block via copy to the provided buffer.
     /// </summary>
     /// <param name="blockBuffer">The buffer to copy the byte block to.</param>
-    /// <returns></returns>
+    /// <returns>Whether a block was successfully dequeued or not.</returns>
     bool TryDequeue(in Span<byte> blockBuffer);
     
     /// <summary>

--- a/Intrinio.Collections/RingBuffers/IRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/IRingBuffer.cs
@@ -17,14 +17,14 @@ public interface IRingBuffer
     /// </summary>
     /// <param name="blockToWrite">The byte block to copy from.</param>
     /// <returns>Whether the block was successfully enqueued or not.</returns>
-    bool TryEnqueue(in ReadOnlySpan<byte> blockToWrite);
+    bool TryEnqueue(ReadOnlySpan<byte> blockToWrite);
     
     /// <summary>
     /// Try to dequeue a byte block via copy to the provided buffer.
     /// </summary>
     /// <param name="blockBuffer">The buffer to copy the byte block to.</param>
     /// <returns>Whether a block was successfully dequeued or not.</returns>
-    bool TryDequeue(in Span<byte> blockBuffer);
+    bool TryDequeue(Span<byte> blockBuffer);
     
     /// <summary>
     /// The count of blocks currently in the ring buffer.

--- a/Intrinio.Collections/RingBuffers/PartitionedRoundRobinDynamicBlockRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/PartitionedRoundRobinDynamicBlockRingBuffer.cs
@@ -6,18 +6,21 @@ using System.Threading;
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using Intrinio.Collections.RingBuffers;
+using System.Buffers.Binary;
 
 /// <summary>
-/// A fixed size group of <see cref="Intrinio.Collections.RingBuffers.SingleProducerRingBuffer"/> partitioned by an index, so that multiple writers may have their own write channel without being locked, while consumption is channel agnostic, thread-safe, and performed in a round-robin style.
+/// A fixed size group of <see cref="Intrinio.Collections.RingBuffers.DynamicBlockSingleProducerRingBuffer"/> partitioned by an index, so that multiple writers may have their own write channel without being locked, while consumption is channel agnostic, thread-safe, and performed in a round-robin style.
 /// </summary>
-public class PartitionedRoundRobinRingBuffer : IPartitionedRingBuffer
+public class PartitionedRoundRobinDynamicBlockRingBuffer : IPartitionedDynamicBlockRingBuffer
 {
     private readonly ulong _concurrency;
     private ulong _readIndex;
-    private readonly SingleProducerRingBuffer[] _queues;
+    private readonly DynamicBlockSingleProducerRingBuffer[] _queues;
     private readonly uint _blockSize;
     private readonly uint _eachBlockCapacity;
     private readonly ulong _totalBlockCapacity;
+    
+    public uint UsableBlockSize { get { return BlockSize - sizeof(UInt32); } }
     
     /// <summary>
     /// The fixed size of each byte block.
@@ -42,7 +45,7 @@ public class PartitionedRoundRobinRingBuffer : IPartitionedRingBuffer
         get
         {
             ulong sum = 0UL;
-            foreach (SingleProducerRingBuffer queue in _queues)
+            foreach (DynamicBlockSingleProducerRingBuffer queue in _queues)
                 sum += queue.Count;
             return sum;
         }
@@ -56,7 +59,7 @@ public class PartitionedRoundRobinRingBuffer : IPartitionedRingBuffer
         get
         {
             ulong sum = 0UL;
-            foreach (SingleProducerRingBuffer queue in _queues)
+            foreach (DynamicBlockSingleProducerRingBuffer queue in _queues)
                 sum += queue.DropCount;
             return sum;
         }
@@ -85,13 +88,13 @@ public class PartitionedRoundRobinRingBuffer : IPartitionedRingBuffer
     }
 
     /// <summary>
-    /// A fixed size group of <see cref="Intrinio.Collections.RingBuffers.SingleProducerRingBuffer"/> partitioned by an index, so that multiple writers may have their own write channel without being locked, while consumption is channel agnostic, thread-safe, and performed in a round-robin style.
+    /// A fixed size group of <see cref="Intrinio.Collections.RingBuffers.DynamicBlockSingleProducerRingBuffer"/> partitioned by an index, so that multiple writers may have their own write channel without being locked, while consumption is channel agnostic, thread-safe, and performed in a round-robin style.  Provides support for dealing with blocks of varying size less than or equal to block size minus sizeof(UInt32). The first sizeof(UInt32) bytes of each block are reserved for tracking the used size of that block.
     /// </summary>
     /// <param name="concurrency">The quantity of concurrent access required for writing. This many channels will be created.</param>
     /// <param name="blockSize">The fixed size of each byte block.</param>
     /// <param name="eachQueueBlockCapacity">The fixed capacity of block count in each channel.</param>
     /// <exception cref="ArgumentException">Throws an ArgumentException if concurrency is zero.</exception>
-    public PartitionedRoundRobinRingBuffer(uint concurrency, uint blockSize, uint eachQueueBlockCapacity)
+    public PartitionedRoundRobinDynamicBlockRingBuffer(uint concurrency, uint blockSize, uint eachQueueBlockCapacity)
     {
         if (concurrency == 0U)
             throw new ArgumentException("Argument concurrency must be greater than zero.", nameof(concurrency));
@@ -101,9 +104,9 @@ public class PartitionedRoundRobinRingBuffer : IPartitionedRingBuffer
         _eachBlockCapacity = eachQueueBlockCapacity;
         _totalBlockCapacity = Convert.ToUInt64(eachQueueBlockCapacity) * this._concurrency;
         this._concurrency = concurrency;
-        _queues = new SingleProducerRingBuffer[concurrency];
+        _queues = new DynamicBlockSingleProducerRingBuffer[concurrency];
         for (int i = 0; i < concurrency; i++)
-            _queues[i] = new SingleProducerRingBuffer(blockSize, eachQueueBlockCapacity);
+            _queues[i] = new DynamicBlockSingleProducerRingBuffer(blockSize, eachQueueBlockCapacity);
     }
 
     /// <summary>
@@ -112,6 +115,7 @@ public class PartitionedRoundRobinRingBuffer : IPartitionedRingBuffer
     /// </summary>
     /// <param name="threadIndex">The zero based index for the channel to try enqueuing to. Max value is concurrency - 1.</param>
     /// <param name="blockToWrite">The byte block to copy from.</param>
+    /// <returns>Whether the block was successfully enqueued or not.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryEnqueue(uint threadIndex, in ReadOnlySpan<byte> blockToWrite)
     {
@@ -122,6 +126,7 @@ public class PartitionedRoundRobinRingBuffer : IPartitionedRingBuffer
     /// Thread-safe try dequeue.  Parameter "blockBuffer" MUST be of length BlockSize! Uses a round-robin method to try dequeuing from channels.
     /// </summary>
     /// <param name="blockBuffer">The buffer to copy the byte block to.</param>
+    /// <returns>Whether a block was successfully dequeued or not.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryDequeue(in Span<byte> blockBuffer)
     {
@@ -129,6 +134,33 @@ public class PartitionedRoundRobinRingBuffer : IPartitionedRingBuffer
         while (tryCount < _concurrency && !_queues[Interlocked.Increment(ref _readIndex) % _concurrency].TryDequeue(blockBuffer))
             tryCount++;
         return tryCount != _concurrency;
+    }
+
+    /// <summary>
+    /// Not thread-safe try enqueue.  Parameter "blockToWrite" MUST be of length BlockSize! This is not safe for calling concurrently, and intended for use with a single producer.
+    /// Full behavior: the block trying to be enqueued will be dropped. 
+    /// </summary>
+    /// <param name="threadIndex">The zero based index for the channel to try enqueuing to. Max value is concurrency - 1.</param>
+    /// <param name="fullBlockToWrite">The byte block to copy from.</param>
+    /// <param name="usedBlock">Full block, windowed for the writable area and trimmed down to the used size.</param>
+    /// <returns>Whether the block was successfully enqueued or not.</returns>
+    public bool TryEnqueue(uint threadIndex, in Span<byte> fullBlockToWrite, in Span<byte> usedBlock)
+    {
+        return _queues[threadIndex].TryEnqueue(fullBlockToWrite, usedBlock);
+    }
+
+    /// <summary>
+    /// Try to dequeue a byte block via copy to the provided buffer.
+    /// </summary>
+    /// <param name="fullBlockBuffer">The full sized buffer to copy the byte block to.</param>
+    /// <param name="trimmedBlock">The buffer, trimmed down to the used size.</param>
+    /// <returns>Whether the dequeue successfully retrieved a block or not.</returns>
+    public bool TryDequeue(in Span<byte> fullBlockBuffer, out ReadOnlySpan<byte> trimmedBlock)
+    {
+        bool result = TryDequeue(fullBlockBuffer);
+        uint size = BinaryPrimitives.ReadUInt32BigEndian(fullBlockBuffer);
+        trimmedBlock = fullBlockBuffer.Slice(sizeof(UInt32), Convert.ToInt32(size));
+        return result;
     }
 
     /// <summary>
@@ -151,5 +183,16 @@ public class PartitionedRoundRobinRingBuffer : IPartitionedRingBuffer
     public ulong GetDropCount(int threadIndex)
     {
         return _queues[threadIndex].DropCount;
+    }
+    
+    /// <summary>
+    /// Slice the full block to the writable area (removing the internally tracked used size section).
+    /// </summary>
+    /// <param name="fullBlockToTrim">The full sized block.</param>
+    /// <param name="trimmedBlock">The full sized block, trimmed down to the writable area (internally tracked used size section removed).</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void GetWritableArea(in ReadOnlySpan<byte> fullBlockToTrim, out ReadOnlySpan<byte> trimmedBlock)
+    {
+        DynamicBlockSingleProducerRingBuffer.GetWritableArea(in fullBlockToTrim, out trimmedBlock);
     }
 }

--- a/Intrinio.Collections/RingBuffers/PartitionedRoundRobinDynamicBlockRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/PartitionedRoundRobinDynamicBlockRingBuffer.cs
@@ -3,9 +3,7 @@ namespace Intrinio.Collections.RingBuffers;
 using System;
 using System.Linq;
 using System.Threading;
-using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
-using Intrinio.Collections.RingBuffers;
 using System.Buffers.Binary;
 
 /// <summary>

--- a/Intrinio.Collections/RingBuffers/PartitionedRoundRobinDynamicBlockRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/PartitionedRoundRobinDynamicBlockRingBuffer.cs
@@ -114,7 +114,7 @@ public class PartitionedRoundRobinDynamicBlockRingBuffer : IPartitionedDynamicBl
     /// Full behavior: the block trying to be enqueued will be dropped. 
     /// </summary>
     /// <param name="threadIndex">The zero based index for the channel to try enqueuing to. Max value is concurrency - 1.</param>
-    /// <param name="blockToWrite">The byte block to copy from.</param>
+    /// <param name="blockToWrite">The full length byte block to copy from.</param>
     /// <returns>Whether the block was successfully enqueued or not.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryEnqueue(uint threadIndex, ReadOnlySpan<byte> blockToWrite)
@@ -141,12 +141,13 @@ public class PartitionedRoundRobinDynamicBlockRingBuffer : IPartitionedDynamicBl
     /// Full behavior: the block trying to be enqueued will be dropped. 
     /// </summary>
     /// <param name="threadIndex">The zero based index for the channel to try enqueuing to. Max value is concurrency - 1.</param>
-    /// <param name="fullBlockToWrite">The byte block to copy from.</param>
-    /// <param name="usedBlock">Full block, windowed for the writable area and trimmed down to the used size.</param>
+    /// <param name="fullBlockToWrite">The full length byte block to copy from. MUST be of length BlockSize!</param>
+    /// <param name="usedLength">The length of used space in fullBlockToWrite, not including the section for used size tracking.  Use GetUsableArea to aid in this, and then use the length of that span after your further manipulation here.</param>
     /// <returns>Whether the block was successfully enqueued or not.</returns>
-    public bool TryEnqueue(uint threadIndex, Span<byte> fullBlockToWrite, ReadOnlySpan<byte> usedBlock)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryEnqueue(uint threadIndex, Span<byte> fullBlockToWrite, uint usedLength)
     {
-        return _queues[threadIndex].TryEnqueue(fullBlockToWrite, usedBlock);
+        return _queues[threadIndex].TryEnqueue(fullBlockToWrite, usedLength);
     }
 
     /// <summary>
@@ -155,6 +156,7 @@ public class PartitionedRoundRobinDynamicBlockRingBuffer : IPartitionedDynamicBl
     /// <param name="fullBlockBuffer">The full sized buffer to copy the byte block to.</param>
     /// <param name="usedSize">The used size of the full block.</param>
     /// <returns>Whether the dequeue successfully retrieved a block or not.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryDequeue(Span<byte> fullBlockBuffer, out uint usedSize)
     {
         bool result = TryDequeue(fullBlockBuffer);

--- a/Intrinio.Collections/RingBuffers/PartitionedRoundRobinRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/PartitionedRoundRobinRingBuffer.cs
@@ -113,7 +113,7 @@ public class PartitionedRoundRobinRingBuffer : IPartitionedRingBuffer
     /// <param name="threadIndex">The zero based index for the channel to try enqueuing to. Max value is concurrency - 1.</param>
     /// <param name="blockToWrite">The byte block to copy from.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool TryEnqueue(uint threadIndex, in ReadOnlySpan<byte> blockToWrite)
+    public bool TryEnqueue(uint threadIndex, ReadOnlySpan<byte> blockToWrite)
     {
         return _queues[threadIndex].TryEnqueue(blockToWrite);
     }
@@ -123,7 +123,7 @@ public class PartitionedRoundRobinRingBuffer : IPartitionedRingBuffer
     /// </summary>
     /// <param name="blockBuffer">The buffer to copy the byte block to.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool TryDequeue(in Span<byte> blockBuffer)
+    public bool TryDequeue(Span<byte> blockBuffer)
     {
         ulong tryCount = 0UL;
         while (tryCount < _concurrency && !_queues[Interlocked.Increment(ref _readIndex) % _concurrency].TryDequeue(blockBuffer))

--- a/Intrinio.Collections/RingBuffers/PartitionedRoundRobinRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/PartitionedRoundRobinRingBuffer.cs
@@ -3,9 +3,7 @@ namespace Intrinio.Collections.RingBuffers;
 using System;
 using System.Linq;
 using System.Threading;
-using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
-using Intrinio.Collections.RingBuffers;
 
 /// <summary>
 /// A fixed size group of <see cref="Intrinio.Collections.RingBuffers.SingleProducerRingBuffer"/> partitioned by an index, so that multiple writers may have their own write channel without being locked, while consumption is channel agnostic, thread-safe, and performed in a round-robin style.

--- a/Intrinio.Collections/RingBuffers/RingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/RingBuffer.cs
@@ -72,7 +72,7 @@ public class RingBuffer : IRingBuffer
     /// Full behavior: the block trying to be enqueued will be dropped. 
     /// </summary>
     /// <param name="blockToWrite">The byte block to copy from.</param>
-    public bool TryEnqueue(in ReadOnlySpan<byte> blockToWrite)
+    public bool TryEnqueue(ReadOnlySpan<byte> blockToWrite)
     {
         if (IsFullNoLock())
         {
@@ -102,7 +102,7 @@ public class RingBuffer : IRingBuffer
     /// Thread-safe try dequeue.  Parameter "blockBuffer" MUST be of length BlockSize!
     /// </summary>
     /// <param name="blockBuffer">The buffer to copy the byte block to.</param>
-    public bool TryDequeue(in Span<byte> blockBuffer)
+    public bool TryDequeue(Span<byte> blockBuffer)
     {
         lock (_readLock)
         {

--- a/Intrinio.Collections/RingBuffers/RingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/RingBuffer.cs
@@ -1,11 +1,8 @@
 namespace Intrinio.Collections.RingBuffers;
 
 using System;
-using System.Linq;
 using System.Threading;
-using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
-using Intrinio.Collections.RingBuffers;
 
 /// <summary>
 /// A thread-safe implementation of the IRingBuffer (multiple producer and multiple consumer).  Full behavior: the block trying to be enqueued will be dropped. 

--- a/Intrinio.Collections/RingBuffers/SingleProducerRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/SingleProducerRingBuffer.cs
@@ -70,7 +70,7 @@ public class SingleProducerRingBuffer : IRingBuffer
     /// Full behavior: the block trying to be enqueued will be dropped. 
     /// </summary>
     /// <param name="blockToWrite">The byte block to copy from.</param>
-    public bool TryEnqueue(in ReadOnlySpan<byte> blockToWrite)
+    public bool TryEnqueue(ReadOnlySpan<byte> blockToWrite)
     {
         if (IsFullNoLock())
         {
@@ -91,7 +91,7 @@ public class SingleProducerRingBuffer : IRingBuffer
     /// Thread-safe try dequeue.  Parameter "blockBuffer" MUST be of length BlockSize!
     /// </summary>
     /// <param name="blockBuffer">The buffer to copy the byte block to.</param>
-    public bool TryDequeue(in Span<byte> blockBuffer)
+    public bool TryDequeue(Span<byte> blockBuffer)
     {
         lock (_readLock)
         {

--- a/Intrinio.Collections/RingBuffers/SingleProducerRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/SingleProducerRingBuffer.cs
@@ -1,11 +1,8 @@
 namespace Intrinio.Collections.RingBuffers;
 
 using System;
-using System.Linq;
 using System.Threading;
-using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
-using Intrinio.Collections.RingBuffers;
 
 /// <summary>
 /// A read thread-safe, write not thread-safe implementation of the IRingBuffer (single producer and multiple consumer).  Full behavior: the block trying to be enqueued will be dropped. 


### PR DESCRIPTION
Introduce dynamic block ring buffers, which still used a fixed length buffer, but allow easily tracking the used space within that buffer.