### PR TITLE
Prevent ARM memory reordering

### DIFF
--- a/Intrinio.Collections.nuspec
+++ b/Intrinio.Collections.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>Intrinio.Collections</id>
-		<version>6.3.0</version>
+		<version>6.4.0</version>
 		<title>Intrinio.Collections</title>
 		<authors>Intrinio</authors>
 		<owners>Intrinio</owners>
@@ -10,7 +10,7 @@
 		<license type="file">LICENSE</license>
 		<projectUrl>https://github.com/intrinio/intrinio-collections</projectUrl>
 		<description>Intrinio library for high performance, special-use collections.</description>
-		<releaseNotes>Version 6.3.0 release.</releaseNotes>
+		<releaseNotes>Version 6.4.0 release.</releaseNotes>
 		<copyright>Copyright 2025 Intrinio</copyright>
 		<tags>collections high-performance real-time concurrency</tags>
 		<dependencies>

--- a/Intrinio.Collections/Intrinio.Collections.csproj
+++ b/Intrinio.Collections/Intrinio.Collections.csproj
@@ -11,7 +11,7 @@
         <PackageTags>collections high-performance real-time concurrency</PackageTags>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Version>6.3.0</Version>
+        <Version>6.4.0</Version>
         <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 

--- a/Intrinio.Collections/RingBuffers/DynamicBlockNoLockDropOldestRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/DynamicBlockNoLockDropOldestRingBuffer.cs
@@ -102,13 +102,14 @@ public class DynamicBlockNoLockDropOldestRingBuffer: IDynamicBlockRingBuffer
                         ulong slot = (currRead % _blockCapacity);
                         // Spin with Yield until written (1)
                         while (Volatile.Read(ref _slotStates[slot]) != 1)
-                        {
                             Thread.Yield();
-                        }
+                        
+                        Thread.MemoryBarrier();
                         byte[] block = Volatile.Read(ref _blocks[slot]);
                         Thread.MemoryBarrier();
                         Volatile.Write(ref _blocks[slot], null);
                         _pool.Return(block, false);
+                            
                         Volatile.Write(ref _slotStates[slot], 0); // Back to free
                         Interlocked.Increment(ref _dropCount);
                     }
@@ -125,9 +126,7 @@ public class DynamicBlockNoLockDropOldestRingBuffer: IDynamicBlockRingBuffer
                 ulong slot = currentWrite % _blockCapacity;
                 // Precautionary spin with Yield until free (should be immediate in most cases)
                 while (Volatile.Read(ref _slotStates[slot]) != 0)
-                {
                     Thread.Yield();
-                }
                 
                 _blockLengths[slot] = length;
                 Thread.MemoryBarrier();
@@ -165,15 +164,16 @@ public class DynamicBlockNoLockDropOldestRingBuffer: IDynamicBlockRingBuffer
                 ulong slot = currentRead % _blockCapacity;
                 // Spin with Yield until written (state=1)
                 while (Volatile.Read(ref _slotStates[slot]) != 1)
-                {
                     Thread.Yield();
-                }
+                
+                Thread.MemoryBarrier();
                 byte[] block = Volatile.Read(ref _blocks[slot]);
                 Thread.MemoryBarrier();
                 new Span<byte>(block, 0, (int)_blockSize).CopyTo(fullBlockBuffer);
                 
                 Volatile.Write(ref _blocks[slot], null);
                 _pool.Return(block, false);
+                    
                 Volatile.Write(ref _slotStates[slot], 0); // Back to free
                 Interlocked.Increment(ref _processed);
                 return true;
@@ -211,9 +211,9 @@ public class DynamicBlockNoLockDropOldestRingBuffer: IDynamicBlockRingBuffer
                 ulong slot = currentRead % _blockCapacity;
                 // Spin with Yield until written (state=1)
                 while (Volatile.Read(ref _slotStates[slot]) != 1)
-                {
                     Thread.Yield();
-                }
+                    
+                Thread.MemoryBarrier();
                 byte[] block = Volatile.Read(ref _blocks[slot]);
                 Thread.MemoryBarrier();
                 int length = _blockLengths[slot];
@@ -222,6 +222,7 @@ public class DynamicBlockNoLockDropOldestRingBuffer: IDynamicBlockRingBuffer
                 
                 Volatile.Write(ref _blocks[slot], null);
                 _pool.Return(block, false);
+                    
                 Volatile.Write(ref _slotStates[slot], 0); // Back to free
                 Interlocked.Increment(ref _processed);
                 return true;

--- a/Intrinio.Collections/RingBuffers/DynamicBlockNoLockRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/DynamicBlockNoLockRingBuffer.cs
@@ -151,6 +151,7 @@ public class DynamicBlockNoLockRingBuffer: IDynamicBlockRingBuffer
                 while (Volatile.Read(ref _slotStates[slot]) != 1)
                     Thread.Yield();
                 
+                Thread.MemoryBarrier();
                 byte[] block = Volatile.Read(ref _blocks[slot]);
                 Thread.MemoryBarrier();
                 new Span<byte>(block, 0, Convert.ToInt32(_blockSize)).CopyTo(fullBlockBuffer);
@@ -198,10 +199,9 @@ public class DynamicBlockNoLockRingBuffer: IDynamicBlockRingBuffer
                 
                 // Spin with Yield until written (state=1)
                 while (Volatile.Read(ref _slotStates[slot]) != 1)
-                {
                     Thread.Yield();
-                }
                 
+                Thread.MemoryBarrier();
                 byte[] block = Volatile.Read(ref _blocks[slot]);
                 Thread.MemoryBarrier();
                 int length = _blockLengths[slot];

--- a/Intrinio.Collections/RingBuffers/NoLockDropOldestRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/NoLockDropOldestRingBuffer.cs
@@ -98,13 +98,14 @@ public class NoLockDropOldestRingBuffer : IRingBuffer
                         ulong slot = currRead % _blockCapacity;
                         // Spin with Yield until written (1)
                         while (Volatile.Read(ref _slotStates[slot]) != 1)
-                        {
                             Thread.Yield();
-                        }
+                            
+                        Thread.MemoryBarrier();
                         byte[] block = Volatile.Read(ref _blocks[slot]);
                         Thread.MemoryBarrier();
                         Volatile.Write(ref _blocks[slot], null);
                         _pool.Return(block, false);
+                            
                         Volatile.Write(ref _slotStates[slot], 0); // Back to free
                         Interlocked.Increment(ref _dropCount);
                     }
@@ -121,9 +122,8 @@ public class NoLockDropOldestRingBuffer : IRingBuffer
                 ulong slot = currentWrite % _blockCapacity;
                 // Precautionary spin with Yield until free (should be immediate in most cases)
                 while (Volatile.Read(ref _slotStates[slot]) != 0)
-                {
                     Thread.Yield();
-                }
+                    
                 Thread.MemoryBarrier();
                 Volatile.Write(ref _blocks[slot], rented);
                 Thread.MemoryBarrier();
@@ -159,15 +159,16 @@ public class NoLockDropOldestRingBuffer : IRingBuffer
                 ulong slot = currentRead % _blockCapacity;
                 // Spin with Yield until written (1)
                 while (Volatile.Read(ref _slotStates[slot]) != 1)
-                {
                     Thread.Yield();
-                }
+                
+                Thread.MemoryBarrier();
                 byte[] block = Volatile.Read(ref _blocks[slot]);
                 Thread.MemoryBarrier();
                 new Span<byte>(block, 0, (int)_blockSize).CopyTo(fullBlockBuffer);
                 
                 Volatile.Write(ref _blocks[slot], null);
                 _pool.Return(block, false);
+                    
                 Volatile.Write(ref _slotStates[slot], 0); // Back to free
                 Interlocked.Increment(ref _processed);
                 return true;
@@ -259,9 +260,8 @@ public class NoLockDropOldestRingBuffer<T> : IRingBuffer<T> where T : struct
                         ulong slot = currRead % _capacity;
                         // Spin with Yield until written (1)
                         while (Volatile.Read(ref _slotStates[slot]) != 1)
-                        {
                             Thread.Yield();
-                        }
+                        
                         Thread.MemoryBarrier();
                         Volatile.Write(ref _slotStates[slot], 0); // Back to free (no pool return for struct)
                         Interlocked.Increment(ref _dropCount);
@@ -279,9 +279,8 @@ public class NoLockDropOldestRingBuffer<T> : IRingBuffer<T> where T : struct
                 ulong slot = currentWrite % _capacity;
                 // Precautionary spin with Yield until free (should be immediate in most cases)
                 while (Volatile.Read(ref _slotStates[slot]) != 0)
-                {
                     Thread.Yield();
-                }
+                
                 _data[slot] = obj;
                 Thread.MemoryBarrier();
                 Volatile.Write(ref _slotStates[slot], 1); // Mark as written last
@@ -320,9 +319,7 @@ public class NoLockDropOldestRingBuffer<T> : IRingBuffer<T> where T : struct
                 
                 // Spin with Yield until written (1)
                 while (Volatile.Read(ref _slotStates[slot]) != 1)
-                {
                     Thread.Yield();
-                }
                 
                 obj = _data[slot];
                 Thread.MemoryBarrier();
@@ -332,4 +329,4 @@ public class NoLockDropOldestRingBuffer<T> : IRingBuffer<T> where T : struct
             }
         }
     }
-}
+}   

--- a/Intrinio.Collections/RingBuffers/NoLockRingBuffer.cs
+++ b/Intrinio.Collections/RingBuffers/NoLockRingBuffer.cs
@@ -143,9 +143,9 @@ public class NoLockRingBuffer : IRingBuffer
                 ulong slot = currentRead % _blockCapacity;
                 // Spin with Yield until written (state=1)
                 while (Volatile.Read(ref _slotStates[slot]) != 1)
-                {
                     Thread.Yield();
-                }
+                
+                Thread.MemoryBarrier();
                 byte[] block = Volatile.Read(ref _blocks[slot]);
                 Thread.MemoryBarrier();
                 new Span<byte>(block, 0, (int)_blockSize).CopyTo(fullBlockBuffer);


### PR DESCRIPTION
Prevent ARM memory reordering from causing an argument null exception when trying to return rented arrays.